### PR TITLE
constrained camera radius and beta values

### DIFF
--- a/src/objects/Camera.ts
+++ b/src/objects/Camera.ts
@@ -7,7 +7,7 @@ export default class UFICamera extends EntityObject {
     scene: Scene,
     canvas: any,
     position: Vector3 = undefined,
-    radius = 10
+    radius = 30
   ) {
     super(scene, "camera");
 
@@ -19,6 +19,10 @@ export default class UFICamera extends EntityObject {
       position,
       scene
     );
+    this.camObj.lowerRadiusLimit = radius / 2;
+    this.camObj.upperRadiusLimit = radius * 3;
+    this.camObj.lowerBetaLimit = BABYLON.Tools.ToRadians(45);
+    this.camObj.upperBetaLimit = BABYLON.Tools.ToRadians(135);
 
     this.camObj.attachControl(canvas, true);
   }


### PR DESCRIPTION
Currently beta can change by at most 45 degrees and radius is between 15 and 90 units.
These values do not seem bad to me, especially due to our 2.5D nature.

Maybe later we can make it so that the camera does not look from inside objects, ie. the camera should not be able to go below the ground.